### PR TITLE
fix: add venv to PATH in default-etl Dockerfile

### DIFF
--- a/projects/default-etl/Dockerfile
+++ b/projects/default-etl/Dockerfile
@@ -16,6 +16,8 @@ RUN uv sync --frozen --no-dev --all-extras
 
 ENV DAGSTER_HOME=/opt/dagster/dagster_home
 ENV PYTHONPATH="/app/projects/default-etl/src:${PYTHONPATH}"
+# Put the venv on PATH so the k8s chart can exec `dagster` directly (it bypasses `uv run`)
+ENV PATH="/app/.venv/bin:${PATH}"
 RUN mkdir -p "${DAGSTER_HOME}"
 
 EXPOSE 3030


### PR DESCRIPTION
## Problem

The Dagster Helm chart execs `dagster` directly (for gRPC health checks and the code-server entrypoint), bypassing `uv run`. The image installs dependencies into a uv virtualenv at `/app/.venv`, but that directory was not on `PATH`, causing pods to fail with:

```
RunContainerError: exec: "dagster": executable file not found in $PATH
```

## Fix

Add `ENV PATH="/app/.venv/bin:${PATH}"` to the Dockerfile. This ensures `dagster` (and any other venv binaries) are found whether the process is launched via `uv run` or directly.

This affects **anyone** deploying this chart with this image, not just local setups.