### PR TITLE
fix: correct Dagster module name in values-local.yaml

### DIFF
--- a/deploy/kubernetes/srdp-chart/values-local.yaml
+++ b/deploy/kubernetes/srdp-chart/values-local.yaml
@@ -69,5 +69,5 @@ dagster:
           repository: rg.nl-ams.scw.cloud/srdp-registry/srdp-etl
           tag: "v1.0"
           pullPolicy: Never
-        dagsterApiGrpcArgs: ["-m", "definitions"]
+        dagsterApiGrpcArgs: ["-m", "etl.definitions"]
         port: 3030


### PR DESCRIPTION
## Problem

`dagsterApiGrpcArgs` in `values-local.yaml` referenced `-m definitions`, but the actual Python module is `etl.definitions` — matching both the package structure under `projects/default-etl/src/etl/` and the `CMD` in the Dockerfile.

With the wrong module name the gRPC code-server fails to start with a `ModuleNotFoundError`, preventing any Dagster jobs from running.

## Fix

Change `["-m", "definitions"]` → `["-m", "etl.definitions"]`.