### PR TITLE
fix: switch local domain from local.dev to srdp.localhost

### DIFF
--- a/deploy/kubernetes/srdp-chart/values-local.yaml
+++ b/deploy/kubernetes/srdp-chart/values-local.yaml
@@ -44,7 +44,7 @@ zitadel:
     customConfigmapConfig: |
       ZITADEL_SERVICE_USER_TOKEN_FILE="/login-client/pat"
       ZITADEL_API_URL="http://srdp-zitadel:8080"
-      CUSTOM_REQUEST_HEADERS="Host:auth.local.dev,X-Zitadel-Public-Host:auth.local.dev"
+      CUSTOM_REQUEST_HEADERS="Host:auth.srdp.localhost,X-Zitadel-Public-Host:auth.srdp.localhost"
 
 oauth2-proxy:
   config:

--- a/deploy/kubernetes/srdp-chart/values.yaml
+++ b/deploy/kubernetes/srdp-chart/values.yaml
@@ -1,6 +1,6 @@
 # Global settings
 global:
-  domain: "local.dev"
+  domain: "srdp.localhost"
 
 # Traefik
 traefik:
@@ -70,7 +70,7 @@ zitadel:
           Admin:
             Password: srdpTest123
     configmapConfig:
-      ExternalDomain: auth.local.dev
+      ExternalDomain: auth.srdp.localhost
       ExternalPort: 443
       TLS:
         Enabled: false
@@ -163,13 +163,13 @@ oauth2-proxy:
     skip-provider-button: "true"
     http-address: "0.0.0.0:4180" 
     cookie-secure: "false" 
-    cookie-domain: ".local.dev"
-    whitelist-domain: ".local.dev"
+    cookie-domain: ".srdp.localhost"
+    whitelist-domain: ".srdp.localhost"
     cookie-samesite: "lax"
     cookie-expire: "168h"
     provider: "oidc"
     provider-display-name: "ZITADEL"
-    oidc-issuer-url: "https://auth.local.dev"
+    oidc-issuer-url: "https://auth.srdp.localhost"
     insecure-oidc-skip-issuer-verification: "true"
     ssl-insecure-skip-verify: "true"
     email-domain: "*"
@@ -177,13 +177,13 @@ oauth2-proxy:
     reverse-proxy: "true"
 
   customRequestHeaders:
-    - "Host:auth.local.dev"
+    - "Host:auth.srdp.localhost"
     - "X-Forwarded-Proto:https"
-  
+
   hostAliases:
     - ip: "10.96.0.50"
       hostnames:
-        - "auth.local.dev"
+        - "auth.srdp.localhost"
 
 # Dagster orchestration
 dagster:

--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -11,7 +11,7 @@ Required tools (all deployment methods)
 - Git
 - Container runtime (Docker Engine + Docker Compose)
 - [`just`](https://github.com/casey/just) — task runner for common commands
-- [`mkcert`](https://github.com/FiloSottaro/mkcert) — local TLS certificates for `*.local.dev`
+- [`mkcert`](https://github.com/FiloSottaro/mkcert) — local TLS certificates for `*.srdp.localhost`
 
 Additional tools for Kubernetes deployment
 - `kubectl` + a Kubernetes cluster (tested with 1.32+)

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -10,7 +10,7 @@ This guide will walk you through the steps to get the Single Repo Data Platform 
 - **Docker Compose** — simplest, no Kubernetes needed, good for trying out the stack locally.
 - **Kubernetes (Helm)** — closer to the production setup, requires a local cluster.
 
-Both options require mkcert for local TLS certificates and `/etc/hosts` entries for the `*.local.dev` domains.
+Both options require mkcert for local TLS certificates and `/etc/hosts` entries for the `*.srdp.localhost` domains.
 
 ---
 
@@ -28,7 +28,7 @@ cd srdp
 Add the following line to your hosts file (`/etc/hosts` on macOS/Linux):
 
 ```
-127.0.0.1 auth.local.dev marimo.local.dev quarto.local.dev dagster.local.dev
+127.0.0.1 auth.srdp.localhost marimo.srdp.localhost quarto.srdp.localhost dagster.srdp.localhost
 ```
 
 ### 3) Install the local CA and generate TLS certificates
@@ -78,7 +78,7 @@ cd srdp
 
 ### 2) Point DNS at your cluster
 
-The chart uses `*.local.dev` by default. Point those hostnames at the IP you will use to reach Traefik:
+The chart uses `*.srdp.localhost` by default. Point those hostnames at the IP you will use to reach Traefik:
 
 - For NodePort/local clusters: `127.0.0.1` is usually fine.
 - For a LoadBalancer: use the external IP once Traefik comes up.
@@ -86,7 +86,7 @@ The chart uses `*.local.dev` by default. Point those hostnames at the IP you wil
 Add one line to your hosts file (`/etc/hosts` on macOS/Linux):
 
 ```
-127.0.0.1 auth.local.dev marimo.local.dev quarto.local.dev dagster.local.dev
+127.0.0.1 auth.srdp.localhost marimo.srdp.localhost quarto.srdp.localhost dagster.srdp.localhost
 ```
 
 ### 3) Install the local CA and generate TLS certificates
@@ -102,7 +102,7 @@ Or manually:
 ```bash
 mkdir -p deploy/kubernetes/certs
 mkcert -cert-file deploy/kubernetes/certs/selfsigned.crt -key-file deploy/kubernetes/certs/selfsigned.key \
-  "auth.local.dev" "marimo.local.dev" "quarto.local.dev" "dagster.local.dev"
+  "auth.srdp.localhost" "marimo.srdp.localhost" "quarto.srdp.localhost" "dagster.srdp.localhost"
 
 kubectl create namespace srdp --dry-run=client -o yaml | kubectl apply -f -
 kubectl create secret tls custom-ingress-cert \

--- a/docs/03-architecture.md
+++ b/docs/03-architecture.md
@@ -63,14 +63,14 @@ Every container has an explicit `container_name` in `docker-compose.yml` to prev
 
 ### Domains
 
-Local development uses `*.local.dev` with mkcert certificates:
+Local development uses `*.srdp.localhost` with mkcert certificates:
 
 | Domain | Service |
 |:---|:---|
-| `auth.local.dev` | Zitadel |
-| `dagster.local.dev` | Dagster webserver |
-| `marimo.local.dev` | Marimo |
-| `quarto.local.dev` | Quarto |
+| `auth.srdp.localhost` | Zitadel |
+| `dagster.srdp.localhost` | Dagster webserver |
+| `marimo.srdp.localhost` | Marimo |
+| `quarto.srdp.localhost` | Quarto |
 
 ### Databases
 
@@ -104,7 +104,7 @@ Shared across all services. The `initdb/` directory runs SQL scripts on first bo
 
 - Configured as a Traefik forward-auth middleware (`zitadel-auth`).
 - Protects all app services (Marimo, Quarto, Dagster) — requests are redirected to Zitadel for OIDC login.
-- The `dagster.local.dev` domain is included in the oauth2-proxy router rule alongside the other app domains.
+- The `dagster.srdp.localhost` domain is included in the oauth2-proxy router rule alongside the other app domains.
 
 ### Dagster
 

--- a/docs/04-usage.md
+++ b/docs/04-usage.md
@@ -10,10 +10,10 @@ icon: lucide/circle-play
 - `kubectl get pods,svc,ing -n srdp`
 
 ### Access services
-- Marimo: `https://marimo.local.dev`
-- Quarto: `https://quarto.local.dev`
-- Dagster: `https://dagster.local.dev`
-- Zitadel: `https://auth.local.dev`
+- Marimo: `https://marimo.srdp.localhost`
+- Quarto: `https://quarto.srdp.localhost`
+- Dagster: `https://dagster.srdp.localhost`
+- Zitadel: `https://auth.srdp.localhost`
 - Traefik dashboard (if enabled in values): `http://localhost:8080`
 
 All apps (Marimo, Quarto, Dagster) are protected behind OAuth2-Proxy. Accessing any of them will redirect to Zitadel for OIDC login before granting access.
@@ -36,11 +36,11 @@ Once you have completed the setup, you can verify that all services are running 
 Use the following URLs. You will be prompted to authenticate before accessing each service. You can use the admin credentials from [02-configuration.md](./02-configuration.md):
 
 *   **Marimo Dashboard:**
-    *   URL: [https://marimo.local.dev](https://marimo.local.dev)
+    *   URL: [https://marimo.srdp.localhost](https://marimo.srdp.localhost)
     *   You should see an interactive dashboard with a slider.
 
 *   **Quarto Static Site:**
-    *   URL: [https://quarto.local.dev](https://quarto.local.dev)
+    *   URL: [https://quarto.srdp.localhost](https://quarto.srdp.localhost)
     *   You should see a static HTML report titled "My Quarto Report".
 
 *   **Traefik Dashboard (for debugging):**


### PR DESCRIPTION
## Problem

`local.dev` is a real, registered domain served by Cloudflare. VPN clients with DNS leak protection (e.g. ProtonVPN) route all DNS through their own resolver and bypass `/etc/hosts`, so `*.local.dev` resolves to Cloudflare IPs instead of `127.0.0.1`. This causes a confusing `502 server: cloudflare` error with no obvious connection to the VPN.

## Fix

Switch to `*.srdp.localhost`. The `.localhost` TLD is reserved by RFC 2606 and can never be registered or shadowed by a real DNS record, so this failure mode is impossible.

## Changes

- `values.yaml`: `global.domain`, `ExternalDomain`, `cookie-domain`, `whitelist-domain`, `oidc-issuer-url`, `customRequestHeaders`, `hostAliases`
- `values-local.yaml`: `CUSTOM_REQUEST_HEADERS` in the Zitadel login configmap

## Migration for existing local setups

Update `/etc/hosts`:
```
127.0.0.1 auth.srdp.localhost marimo.srdp.localhost quarto.srdp.localhost dagster.srdp.localhost
```

Regenerate the mkcert cert:
```bash
mkcert -cert-file deploy/kubernetes/certs/selfsigned.crt \
       -key-file deploy/kubernetes/certs/selfsigned.key \
       "auth.srdp.localhost" "marimo.srdp.localhost" "quarto.srdp.localhost" "dagster.srdp.localhost"

kubectl create secret tls custom-ingress-cert \
  --namespace srdp \
  --key deploy/kubernetes/certs/selfsigned.key \
  --cert deploy/kubernetes/certs/selfsigned.crt \
  --dry-run=client -o yaml | kubectl apply -f -
```

Re-create the Zitadel OIDC app with updated redirect URIs pointing to `*.srdp.localhost`, then redeploy.